### PR TITLE
Make mCommonProperties thread-safe in AmplitudeProxy

### DIFF
--- a/pixalytics-amplitude/src/main/java/com/thumbtack/pixalytics/amplitude/proxy/AmplitudeProxy.java
+++ b/pixalytics-amplitude/src/main/java/com/thumbtack/pixalytics/amplitude/proxy/AmplitudeProxy.java
@@ -12,8 +12,8 @@ import com.pixable.pixalytics.core.proxy.PlatformProxy;
 
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AmplitudeProxy implements PlatformProxy {
 
@@ -24,7 +24,7 @@ public class AmplitudeProxy implements PlatformProxy {
     private final String mApiKey;
 
     @NonNull
-    private final Map<String, Object> mCommonProperties = new HashMap<>();
+    private final Map<String, Object> mCommonProperties = new ConcurrentHashMap<>();
 
     public AmplitudeProxy(@NonNull final Application application, @NonNull final String apiKey) {
         mApplication = application;


### PR DESCRIPTION
Given that multiple threads could be reading/writing/removing to/from
the common properties, the map needs to be Concurrent to avoid
ConcurrentModificationExceptions